### PR TITLE
Update ruRU.lua

### DIFF
--- a/locale/ruRU.lua
+++ b/locale/ruRU.lua
@@ -1,4 +1,4 @@
--- ruRU Russian
+-- ruRU Russian Translator ZamestoTV
 local _, ImproveAny = ...
 function ImproveAny:Lang_ruRU()
 	local tab = {


### PR DESCRIPTION
The copyright of the original translator, which was removed, has been restored.